### PR TITLE
[android] Add crashlytics support

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,29 @@ In order to install [Performance Monitoring](https://rnfirebase.io/perf/usage) o
 
 </details>
 
+<details>
+<summary>Install Crashlytics for Android</summary>
+
+In order to install [Crashlytics](https://rnfirebase.io/crashlytics/usage) on Android, set `androidOptions.installCrashlytics` to `true`:
+
+```json
+{
+  "plugins": [
+    [
+      "with-rn-firebase",
+      {
+        ...
+        "androidOptions": {
+          "installCrashlytics": true
+        }
+      }
+    ]
+  ]
+}
+```
+
+</details>
+
 ## Building and running
 
 You can either:

--- a/plugin/__tests__/__snapshots__/androidPlugin.test.ts.snap
+++ b/plugin/__tests__/__snapshots__/androidPlugin.test.ts.snap
@@ -284,6 +284,7 @@ buildscript {
         jcenter()
     }
     dependencies {
+        classpath 'com.google.firebase:firebase-crashlytics-gradle:2.7.1'
         classpath 'com.google.gms:google-services:4.3.8'
         classpath(\\"com.android.tools.build:gradle:4.1.0\\")
 

--- a/plugin/__tests__/__snapshots__/androidPlugin.test.ts.snap
+++ b/plugin/__tests__/__snapshots__/androidPlugin.test.ts.snap
@@ -269,6 +269,276 @@ allprojects {
 "
 `;
 
+exports[`Android Tests applies crashlytics classpath to project build.gradle 1`] = `
+"// Top-level build file where you can add configuration options common to all sub-projects/modules.
+
+buildscript {
+    ext {
+        buildToolsVersion = \\"29.0.3\\"
+        minSdkVersion = 21
+        compileSdkVersion = 30
+        targetSdkVersion = 30
+    }
+    repositories {
+        google()
+        jcenter()
+    }
+    dependencies {
+        classpath 'com.google.gms:google-services:4.3.8'
+        classpath(\\"com.android.tools.build:gradle:4.1.0\\")
+
+        // NOTE: Do not place your application dependencies here; they belong
+        // in the individual module build.gradle files
+    }
+}
+
+allprojects {
+    repositories {
+        mavenLocal()
+        maven {
+            // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
+            url(\\"$rootDir/../node_modules/react-native/android\\")
+        }
+        maven {
+            // Android JSC is installed from npm
+            url(\\"$rootDir/../node_modules/jsc-android/dist\\")
+        }
+
+        google()
+        jcenter()
+        maven { url 'https://www.jitpack.io' }
+    }
+}
+"
+`;
+
+exports[`Android Tests applies crashlytics plugin to app/build.gradle 1`] = `
+"/* Example build.gradle file from https://github.com/expo/expo/blob/6ab0274b5cb9a9c223e0d453787a522b438b4fcb/templates/expo-template-bare-minimum/android/app/build.gradle */
+
+apply plugin: \\"com.android.application\\"
+
+import com.android.build.OutputFile
+
+/**
+ * The react.gradle file registers a task for each build variant (e.g. bundleDebugJsAndAssets
+ * and bundleReleaseJsAndAssets).
+ * These basically call \`react-native bundle\` with the correct arguments during the Android build
+ * cycle. By default, bundleDebugJsAndAssets is skipped, as in debug/dev mode we prefer to load the
+ * bundle directly from the development server. Below you can see all the possible configurations
+ * and their defaults. If you decide to add a configuration block, make sure to add it before the
+ * \`apply from: \\"../../node_modules/react-native/react.gradle\\"\` line.
+ *
+ * project.ext.react = [
+ *   // the name of the generated asset file containing your JS bundle
+ *   bundleAssetName: \\"index.android.bundle\\",
+ *
+ *   // the entry file for bundle generation. If none specified and
+ *   // \\"index.android.js\\" exists, it will be used. Otherwise \\"index.js\\" is
+ *   // default. Can be overridden with ENTRY_FILE environment variable.
+ *   entryFile: \\"index.android.js\\",
+ *
+ *   // https://reactnative.dev/docs/performance#enable-the-ram-format
+ *   bundleCommand: \\"ram-bundle\\",
+ *
+ *   // whether to bundle JS and assets in debug mode
+ *   bundleInDebug: false,
+ *
+ *   // whether to bundle JS and assets in release mode
+ *   bundleInRelease: true,
+ *
+ *   // whether to bundle JS and assets in another build variant (if configured).
+ *   // See http://tools.android.com/tech-docs/new-build-system/user-guide#TOC-Build-Variants
+ *   // The configuration property can be in the following formats
+ *   //         'bundleIn\${productFlavor}\${buildType}'
+ *   //         'bundleIn\${buildType}'
+ *   // bundleInFreeDebug: true,
+ *   // bundleInPaidRelease: true,
+ *   // bundleInBeta: true,
+ *
+ *   // whether to disable dev mode in custom build variants (by default only disabled in release)
+ *   // for example: to disable dev mode in the staging build type (if configured)
+ *   devDisabledInStaging: true,
+ *   // The configuration property can be in the following formats
+ *   //         'devDisabledIn\${productFlavor}\${buildType}'
+ *   //         'devDisabledIn\${buildType}'
+ *
+ *   // the root of your project, i.e. where \\"package.json\\" lives
+ *   root: \\"../../\\",
+ *
+ *   // where to put the JS bundle asset in debug mode
+ *   jsBundleDirDebug: \\"$buildDir/intermediates/assets/debug\\",
+ *
+ *   // where to put the JS bundle asset in release mode
+ *   jsBundleDirRelease: \\"$buildDir/intermediates/assets/release\\",
+ *
+ *   // where to put drawable resources / React Native assets, e.g. the ones you use via
+ *   // require('./image.png')), in debug mode
+ *   resourcesDirDebug: \\"$buildDir/intermediates/res/merged/debug\\",
+ *
+ *   // where to put drawable resources / React Native assets, e.g. the ones you use via
+ *   // require('./image.png')), in release mode
+ *   resourcesDirRelease: \\"$buildDir/intermediates/res/merged/release\\",
+ *
+ *   // by default the gradle tasks are skipped if none of the JS files or assets change; this means
+ *   // that we don't look at files in android/ or ios/ to determine whether the tasks are up to
+ *   // date; if you have any other folders that you want to ignore for performance reasons (gradle
+ *   // indexes the entire tree), add them here. Alternatively, if you have JS files in android/
+ *   // for example, you might want to remove it from here.
+ *   inputExcludes: [\\"android/**\\", \\"ios/**\\"],
+ *
+ *   // override which node gets called and with what additional arguments
+ *   nodeExecutableAndArgs: [\\"node\\"],
+ *
+ *   // supply additional arguments to the packager
+ *   extraPackagerArgs: []
+ * ]
+ */
+
+project.ext.react = [
+    enableHermes: false
+]
+
+apply from: '../../node_modules/react-native-unimodules/gradle.groovy'
+apply from: \\"../../node_modules/react-native/react.gradle\\"
+apply from: \\"../../node_modules/expo-constants/scripts/get-app-config-android.gradle\\"
+apply from: \\"../../node_modules/expo-updates/scripts/create-manifest-android.gradle\\"
+
+/**
+ * Set this to true to create two separate APKs instead of one:
+ *   - An APK that only works on ARM devices
+ *   - An APK that only works on x86 devices
+ * The advantage is the size of the APK is reduced by about 4MB.
+ * Upload all the APKs to the Play Store and people will download
+ * the correct one based on the CPU architecture of their device.
+ */
+def enableSeparateBuildPerCPUArchitecture = false
+
+/**
+ * Run Proguard to shrink the Java bytecode in release builds.
+ */
+def enableProguardInReleaseBuilds = false
+
+/**
+ * The preferred build flavor of JavaScriptCore.
+ *
+ * For example, to use the international variant, you can use:
+ * \`def jscFlavor = 'org.webkit:android-jsc-intl:+'\`
+ *
+ * The international variant includes ICU i18n library and necessary data
+ * allowing to use e.g. \`Date.toLocaleString\` and \`String.localeCompare\` that
+ * give correct results when using with locales other than en-US.  Note that
+ * this variant is about 6MiB larger per architecture than default.
+ */
+def jscFlavor = 'org.webkit:android-jsc:+'
+
+/**
+ * Whether to enable the Hermes VM.
+ *
+ * This should be set on project.ext.react and mirrored here.  If it is not set
+ * on project.ext.react, JavaScript will not be compiled to Hermes Bytecode
+ * and the benefits of using Hermes will therefore be sharply reduced.
+ */
+def enableHermes = project.ext.react.get(\\"enableHermes\\", false);
+
+android {
+    compileSdkVersion rootProject.ext.compileSdkVersion
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
+    defaultConfig {
+        applicationId \\"com.helloworld\\"
+        minSdkVersion rootProject.ext.minSdkVersion
+        targetSdkVersion rootProject.ext.targetSdkVersion
+        versionCode 1
+        versionName \\"1.0\\"
+    }
+    splits {
+        abi {
+            reset()
+            enable enableSeparateBuildPerCPUArchitecture
+            universalApk false  // If true, also generate a universal APK
+            include \\"armeabi-v7a\\", \\"x86\\", \\"arm64-v8a\\", \\"x86_64\\"
+        }
+    }
+    signingConfigs {
+        debug {
+            storeFile file('debug.keystore')
+            storePassword 'android'
+            keyAlias 'androiddebugkey'
+            keyPassword 'android'
+        }
+    }
+    buildTypes {
+        debug {
+            signingConfig signingConfigs.debug
+        }
+        release {
+            // Caution! In production, you need to generate your own keystore file.
+            // see https://reactnative.dev/docs/signed-apk-android.
+            signingConfig signingConfigs.debug
+            minifyEnabled enableProguardInReleaseBuilds
+            proguardFiles getDefaultProguardFile(\\"proguard-android.txt\\"), \\"proguard-rules.pro\\"
+        }
+    }
+
+    // applicationVariants are e.g. debug, release
+    applicationVariants.all { variant ->
+        variant.outputs.each { output ->
+            // For each separate APK per architecture, set a unique version code as described here:
+            // https://developer.android.com/studio/build/configure-apk-splits.html
+            def versionCodes = [\\"armeabi-v7a\\": 1, \\"x86\\": 2, \\"arm64-v8a\\": 3, \\"x86_64\\": 4]
+            def abi = output.getFilter(OutputFile.ABI)
+            if (abi != null) {  // null for the universal-debug, universal-release variants
+                output.versionCodeOverride =
+                        versionCodes.get(abi) * 1048576 + defaultConfig.versionCode
+            }
+
+        }
+    }
+}
+
+dependencies {
+    implementation fileTree(dir: \\"libs\\", include: [\\"*.jar\\"])
+    //noinspection GradleDynamicVersion
+    implementation \\"com.facebook.react:react-native:+\\"  // From node_modules
+    implementation \\"androidx.swiperefreshlayout:swiperefreshlayout:1.0.0\\"
+    debugImplementation(\\"com.facebook.flipper:flipper:\${FLIPPER_VERSION}\\") {
+      exclude group:'com.facebook.fbjni'
+    }
+    debugImplementation(\\"com.facebook.flipper:flipper-network-plugin:\${FLIPPER_VERSION}\\") {
+        exclude group:'com.facebook.flipper'
+        exclude group:'com.squareup.okhttp3', module:'okhttp'
+    }
+    debugImplementation(\\"com.facebook.flipper:flipper-fresco-plugin:\${FLIPPER_VERSION}\\") {
+        exclude group:'com.facebook.flipper'
+    }
+    addUnimodulesDependencies()
+
+    if (enableHermes) {
+        def hermesPath = \\"../../node_modules/hermes-engine/android/\\";
+        debugImplementation files(hermesPath + \\"hermes-debug.aar\\")
+        releaseImplementation files(hermesPath + \\"hermes-release.aar\\")
+    } else {
+        implementation jscFlavor
+    }
+}
+
+// Run this once to be able to run the application with BUCK
+// puts all compile dependencies into folder libs for BUCK to use
+task copyDownloadableDepsToLibs(type: Copy) {
+    from configurations.compile
+    into 'libs'
+}
+
+apply from: file(\\"../../node_modules/@react-native-community/cli-platform-android/native_modules.gradle\\"); applyNativeModulesAppBuildGradle(project)
+
+apply plugin: 'com.google.gms.google-services'
+apply plugin: 'com.google.firebase.crashlytics'"
+`;
+
 exports[`Android Tests applies perf monitoring classpath to project build.gradle 1`] = `
 "// Top-level build file where you can add configuration options common to all sub-projects/modules.
 

--- a/plugin/__tests__/androidPlugin.test.ts
+++ b/plugin/__tests__/androidPlugin.test.ts
@@ -21,22 +21,32 @@ describe("Android Tests", () => {
   });
 
   it("applies changes to project build.gradle", async () => {
-    const result = setBuildscriptDependency(projectBuildGradle, false);
+    const result = setBuildscriptDependency(projectBuildGradle, false, false);
     expect(result).toMatchSnapshot();
   });
 
   it("applies changes to app/build.gradle", async () => {
-    const result = applyPlugin(appBuildGradle, false);
+    const result = applyPlugin(appBuildGradle, false, false);
     expect(result).toMatchSnapshot();
   });
 
   it("applies perf monitoring classpath to project build.gradle", async () => {
-    const result = setBuildscriptDependency(projectBuildGradle, true);
+    const result = setBuildscriptDependency(projectBuildGradle, true, false);
     expect(result).toMatchSnapshot();
   });
 
   it("applies perf monitoring plugin to app/build.gradle", async () => {
-    const result = applyPlugin(appBuildGradle, true);
+    const result = applyPlugin(appBuildGradle, true, false);
+    expect(result).toMatchSnapshot();
+  });
+
+  it("applies crashlytics classpath to project build.gradle", async () => {
+    const result = setBuildscriptDependency(projectBuildGradle, false, true);
+    expect(result).toMatchSnapshot();
+  });
+
+  it("applies crashlytics plugin to app/build.gradle", async () => {
+    const result = applyPlugin(appBuildGradle, false, true);
     expect(result).toMatchSnapshot();
   });
 });

--- a/plugin/build/android/applyPlugin.d.ts
+++ b/plugin/build/android/applyPlugin.d.ts
@@ -4,4 +4,4 @@ import { AndroidProps } from "./props";
  * Update `app/build.gradle` by applying google-services plugin
  */
 export declare const withApplyGoogleServicesPlugin: ConfigPlugin<AndroidProps>;
-export declare function applyPlugin(appBuildGradle: string, installPerfMonitoring: boolean): string;
+export declare function applyPlugin(appBuildGradle: string, installPerfMonitoring: boolean, installCrashlytics: boolean): string;

--- a/plugin/build/android/applyPlugin.js
+++ b/plugin/build/android/applyPlugin.js
@@ -6,10 +6,10 @@ const constants_1 = require("./constants");
 /**
  * Update `app/build.gradle` by applying google-services plugin
  */
-const withApplyGoogleServicesPlugin = (config, { installPerfMonitoring }) => {
+const withApplyGoogleServicesPlugin = (config, { installPerfMonitoring, installCrashlytics }) => {
     return config_plugins_1.withAppBuildGradle(config, (config) => {
         if (config.modResults.language === "groovy") {
-            config.modResults.contents = applyPlugin(config.modResults.contents, installPerfMonitoring !== null && installPerfMonitoring !== void 0 ? installPerfMonitoring : false);
+            config.modResults.contents = applyPlugin(config.modResults.contents, installPerfMonitoring !== null && installPerfMonitoring !== void 0 ? installPerfMonitoring : false, installCrashlytics !== null && installCrashlytics !== void 0 ? installCrashlytics : false);
         }
         else {
             config_plugins_1.WarningAggregator.addWarningAndroid("android-google-services", `Cannot automatically configure app build.gradle if it's not groovy`);
@@ -18,12 +18,16 @@ const withApplyGoogleServicesPlugin = (config, { installPerfMonitoring }) => {
     });
 };
 exports.withApplyGoogleServicesPlugin = withApplyGoogleServicesPlugin;
-function applyPlugin(appBuildGradle, installPerfMonitoring) {
+function applyPlugin(appBuildGradle, installPerfMonitoring, installCrashlytics) {
     let newBuildGradle = appBuildGradle;
     // Make sure the project does not have the plugin already
     const pattern = new RegExp(`apply\\s+plugin:\\s+['"]${constants_1.googleServicesPlugin}['"]`);
     if (!newBuildGradle.match(pattern)) {
         newBuildGradle += `\napply plugin: '${constants_1.googleServicesPlugin}'`;
+    }
+    const crashlyticsPattern = new RegExp(`apply\\s+plugin:\\s+['"]${constants_1.crashlyticsPlugin}['"]`);
+    if (installCrashlytics && !newBuildGradle.match(crashlyticsPattern)) {
+        newBuildGradle += `\napply plugin: '${constants_1.crashlyticsPlugin}'`;
     }
     const perfPattern = new RegExp(`apply\\s+plugin:\\s+['"]${constants_1.perfMonitoringPlugin}['"]`);
     if (installPerfMonitoring && !newBuildGradle.match(perfPattern)) {

--- a/plugin/build/android/buildscriptDependency.d.ts
+++ b/plugin/build/android/buildscriptDependency.d.ts
@@ -4,4 +4,4 @@ import { AndroidProps } from "./props";
  * Update `<project>/build.gradle` by adding google-services dependency to buildscript
  */
 export declare const withBuildscriptDependency: ConfigPlugin<AndroidProps>;
-export declare function setBuildscriptDependency(buildGradle: string, installPerfMonitoring: boolean): string;
+export declare function setBuildscriptDependency(buildGradle: string, installPerfMonitoring: boolean, installCrashlytics: boolean): string;

--- a/plugin/build/android/buildscriptDependency.js
+++ b/plugin/build/android/buildscriptDependency.js
@@ -6,10 +6,10 @@ const constants_1 = require("./constants");
 /**
  * Update `<project>/build.gradle` by adding google-services dependency to buildscript
  */
-const withBuildscriptDependency = (config, { installPerfMonitoring }) => {
+const withBuildscriptDependency = (config, { installPerfMonitoring, installCrashlytics }) => {
     return config_plugins_1.withProjectBuildGradle(config, (config) => {
         if (config.modResults.language === "groovy") {
-            config.modResults.contents = setBuildscriptDependency(config.modResults.contents, installPerfMonitoring !== null && installPerfMonitoring !== void 0 ? installPerfMonitoring : false);
+            config.modResults.contents = setBuildscriptDependency(config.modResults.contents, installPerfMonitoring !== null && installPerfMonitoring !== void 0 ? installPerfMonitoring : false, installCrashlytics !== null && installCrashlytics !== void 0 ? installCrashlytics : false);
         }
         else {
             config_plugins_1.WarningAggregator.addWarningAndroid("android-google-services", `Cannot automatically configure project build.gradle if it's not groovy`);
@@ -18,7 +18,7 @@ const withBuildscriptDependency = (config, { installPerfMonitoring }) => {
     });
 };
 exports.withBuildscriptDependency = withBuildscriptDependency;
-function setBuildscriptDependency(buildGradle, installPerfMonitoring) {
+function setBuildscriptDependency(buildGradle, installPerfMonitoring, installCrashlytics) {
     let newBuildGradle = buildGradle;
     if (!newBuildGradle.includes(constants_1.googleServicesClassPath)) {
         // TODO: Find a more stable solution for this
@@ -29,6 +29,10 @@ function setBuildscriptDependency(buildGradle, installPerfMonitoring) {
         !newBuildGradle.includes(constants_1.perfMonitoringClassPath)) {
         newBuildGradle = newBuildGradle.replace(/dependencies\s?{/, `dependencies {
         classpath '${constants_1.perfMonitoringClassPath}:${constants_1.perfMonitoringVersion}'`);
+    }
+    if (installCrashlytics && !newBuildGradle.includes(constants_1.crashlyticsClassPath)) {
+        newBuildGradle = newBuildGradle.replace(/dependencies\s?{/, `dependencies {
+        classpath '${constants_1.crashlyticsClassPath}:${constants_1.crashlyticsVersion}'`);
     }
     return newBuildGradle;
 }

--- a/plugin/build/android/constants.d.ts
+++ b/plugin/build/android/constants.d.ts
@@ -5,3 +5,6 @@ export declare const googleServicesVersion = "4.3.8";
 export declare const perfMonitoringClassPath = "com.google.firebase:perf-plugin";
 export declare const perfMonitoringPlugin = "com.google.firebase.firebase-perf";
 export declare const perfMonitoringVersion = "1.4.0";
+export declare const crashlyticsClassPath = "com.google.firebase:firebase-crashlytics-gradle";
+export declare const crashlyticsPlugin = "com.google.firebase.crashlytics";
+export declare const crashlyticsVersion = "2.7.1";

--- a/plugin/build/android/constants.js
+++ b/plugin/build/android/constants.js
@@ -1,6 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.perfMonitoringVersion = exports.perfMonitoringPlugin = exports.perfMonitoringClassPath = exports.googleServicesVersion = exports.googleServicesPlugin = exports.googleServicesClassPath = exports.DEFAULT_TARGET_PATH = void 0;
+exports.crashlyticsVersion = exports.crashlyticsPlugin = exports.crashlyticsClassPath = exports.perfMonitoringVersion = exports.perfMonitoringPlugin = exports.perfMonitoringClassPath = exports.googleServicesVersion = exports.googleServicesPlugin = exports.googleServicesClassPath = exports.DEFAULT_TARGET_PATH = void 0;
 exports.DEFAULT_TARGET_PATH = "app/google-services.json";
 exports.googleServicesClassPath = "com.google.gms:google-services";
 exports.googleServicesPlugin = "com.google.gms.google-services";
@@ -8,3 +8,6 @@ exports.googleServicesVersion = "4.3.8";
 exports.perfMonitoringClassPath = "com.google.firebase:perf-plugin";
 exports.perfMonitoringPlugin = "com.google.firebase.firebase-perf";
 exports.perfMonitoringVersion = "1.4.0";
+exports.crashlyticsClassPath = "com.google.firebase:firebase-crashlytics-gradle";
+exports.crashlyticsPlugin = "com.google.firebase.crashlytics";
+exports.crashlyticsVersion = "2.7.1";

--- a/plugin/build/android/props.d.ts
+++ b/plugin/build/android/props.d.ts
@@ -1,3 +1,4 @@
 export interface AndroidProps {
     installPerfMonitoring?: boolean;
+    installCrashlytics?: boolean;
 }

--- a/plugin/src/android/applyPlugin.ts
+++ b/plugin/src/android/applyPlugin.ts
@@ -4,7 +4,11 @@ import {
   withAppBuildGradle,
 } from "@expo/config-plugins";
 
-import { googleServicesPlugin, perfMonitoringPlugin } from "./constants";
+import {
+  crashlyticsPlugin,
+  googleServicesPlugin,
+  perfMonitoringPlugin,
+} from "./constants";
 import { AndroidProps } from "./props";
 
 /**
@@ -12,13 +16,14 @@ import { AndroidProps } from "./props";
  */
 export const withApplyGoogleServicesPlugin: ConfigPlugin<AndroidProps> = (
   config,
-  { installPerfMonitoring }
+  { installPerfMonitoring, installCrashlytics }
 ) => {
   return withAppBuildGradle(config, (config) => {
     if (config.modResults.language === "groovy") {
       config.modResults.contents = applyPlugin(
         config.modResults.contents,
-        installPerfMonitoring ?? false
+        installPerfMonitoring ?? false,
+        installCrashlytics ?? false
       );
     } else {
       WarningAggregator.addWarningAndroid(
@@ -32,7 +37,8 @@ export const withApplyGoogleServicesPlugin: ConfigPlugin<AndroidProps> = (
 
 export function applyPlugin(
   appBuildGradle: string,
-  installPerfMonitoring: boolean
+  installPerfMonitoring: boolean,
+  installCrashlytics: boolean
 ) {
   let newBuildGradle = appBuildGradle;
 
@@ -42,6 +48,13 @@ export function applyPlugin(
   );
   if (!newBuildGradle.match(pattern)) {
     newBuildGradle += `\napply plugin: '${googleServicesPlugin}'`;
+  }
+
+  const crashlyticsPattern = new RegExp(
+    `apply\\s+plugin:\\s+['"]${crashlyticsPlugin}['"]`
+  );
+  if (installCrashlytics && !newBuildGradle.match(crashlyticsPattern)) {
+    newBuildGradle += `\napply plugin: '${crashlyticsPlugin}'`;
   }
 
   const perfPattern = new RegExp(

--- a/plugin/src/android/buildscriptDependency.ts
+++ b/plugin/src/android/buildscriptDependency.ts
@@ -62,14 +62,14 @@ export function setBuildscriptDependency(
       `dependencies {
         classpath '${perfMonitoringClassPath}:${perfMonitoringVersion}'`
     );
+  }
 
-    if (installCrashlytics && !newBuildGradle.includes(crashlyticsClassPath)) {
-      newBuildGradle = newBuildGradle.replace(
-        /dependencies\s?{/,
-        `dependencies {
-          classpath '${crashlyticsClassPath}:${crashlyticsVersion}'`
-      );
-    }
+  if (installCrashlytics && !newBuildGradle.includes(crashlyticsClassPath)) {
+    newBuildGradle = newBuildGradle.replace(
+      /dependencies\s?{/,
+      `dependencies {
+        classpath '${crashlyticsClassPath}:${crashlyticsVersion}'`
+    );
   }
 
   return newBuildGradle;

--- a/plugin/src/android/buildscriptDependency.ts
+++ b/plugin/src/android/buildscriptDependency.ts
@@ -5,6 +5,8 @@ import {
 } from "@expo/config-plugins";
 
 import {
+  crashlyticsClassPath,
+  crashlyticsVersion,
   googleServicesClassPath,
   googleServicesVersion,
   perfMonitoringClassPath,
@@ -17,13 +19,14 @@ import { AndroidProps } from "./props";
  */
 export const withBuildscriptDependency: ConfigPlugin<AndroidProps> = (
   config,
-  { installPerfMonitoring }
+  { installPerfMonitoring, installCrashlytics }
 ) => {
   return withProjectBuildGradle(config, (config) => {
     if (config.modResults.language === "groovy") {
       config.modResults.contents = setBuildscriptDependency(
         config.modResults.contents,
-        installPerfMonitoring ?? false
+        installPerfMonitoring ?? false,
+        installCrashlytics ?? false
       );
     } else {
       WarningAggregator.addWarningAndroid(
@@ -37,7 +40,8 @@ export const withBuildscriptDependency: ConfigPlugin<AndroidProps> = (
 
 export function setBuildscriptDependency(
   buildGradle: string,
-  installPerfMonitoring: boolean
+  installPerfMonitoring: boolean,
+  installCrashlytics: boolean
 ) {
   let newBuildGradle = buildGradle;
   if (!newBuildGradle.includes(googleServicesClassPath)) {
@@ -58,6 +62,14 @@ export function setBuildscriptDependency(
       `dependencies {
         classpath '${perfMonitoringClassPath}:${perfMonitoringVersion}'`
     );
+
+    if (installCrashlytics && !newBuildGradle.includes(crashlyticsClassPath)) {
+      newBuildGradle = newBuildGradle.replace(
+        /dependencies\s?{/,
+        `dependencies {
+          classpath '${crashlyticsClassPath}:${crashlyticsVersion}'`
+      );
+    }
   }
 
   return newBuildGradle;

--- a/plugin/src/android/constants.ts
+++ b/plugin/src/android/constants.ts
@@ -7,3 +7,8 @@ export const googleServicesVersion = "4.3.8";
 export const perfMonitoringClassPath = "com.google.firebase:perf-plugin";
 export const perfMonitoringPlugin = "com.google.firebase.firebase-perf";
 export const perfMonitoringVersion = "1.4.0";
+
+export const crashlyticsClassPath =
+  "com.google.firebase:firebase-crashlytics-gradle";
+export const crashlyticsPlugin = "com.google.firebase.crashlytics";
+export const crashlyticsVersion = "2.7.1";

--- a/plugin/src/android/props.ts
+++ b/plugin/src/android/props.ts
@@ -1,3 +1,4 @@
 export interface AndroidProps {
   installPerfMonitoring?: boolean;
+  installCrashlytics?: boolean;
 }


### PR DESCRIPTION
Resolves #4 

Addressed the [Crashlytics installation steps for Android](https://rnfirebase.io/crashlytics/android-setup).

- Added `android.installCrashlytics` plugin option
- Updated README

**Future steps**:

- Address the optional NDK release crashlytics setup
